### PR TITLE
ci: add attestation

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -13,17 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install wheel
-        run: pip install wheel
+      - name: Install build dependencies
+        run: pip install wheel build
       - name: Build
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
+      - name: Attest build provenance
+          uses: actions/attest-build-provenance@v1.3.2
+          with:
+            subject-path: ["dist/ops-*-py3-none.any.whl", "dist/ops-*.tar.gz"]
       - name: Publish to test.pypi.org
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Adds basic GitHub attestation for the wheel and source distribution artefacts.

Also update test-publish to match publish, which was missed earlier.

(Testing locally before submitting upstream PR).