### PR TITLE
refactor: reduce the YAML loading and dumping in ops.testing

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -471,7 +471,7 @@ The main improvements in this release are ...
 Read more in the [full release notes on GitHub](link to the GitHub release).
 ```
 
-In the post, outline the key improvements both in `ops` and `ops-scenario` - 
+In the post, outline the key improvements both in `ops` and `ops-scenario` -
 the point here is to encourage people to check out the full notes and to upgrade
 promptly, so ensure that you entice them with the best that the new versions
 have to offer.

--- a/testing/CONTRIBUTING.md
+++ b/testing/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To set up the dependencies you can run:
 
 We recommend using the provided `pre-commit` config. For how to set up git pre-commit: [see here](https://pre-commit.com/).
 If you dislike that, you can always manually remember to `tox -e lint` before you push.
- 
+
 ### Testing
 ```shell
 tox -e fmt           # auto-fix your code as much as possible, including formatting and linting
@@ -48,4 +48,3 @@ tox -e unit          # unit tests
 tox -e lint-tests    # lint testing code
 tox                  # runs 'lint', 'lint-tests' and 'unit' environments
 ```
-

--- a/testing/README.md
+++ b/testing/README.md
@@ -1172,11 +1172,28 @@ That happens automatically behind the scenes whenever you trigger an event;
   working on a machine charm or don't have either way a `bar` container in your `metadata.yaml`, Scenario will flag that
   as inconsistent.
 
+# Overriding default behaviour
+
 ## Bypassing the checker
 
 If you have a clear false negative, are explicitly testing 'edge', inconsistent situations, or for whatever reason the
 checker is in your way, you can set the `SCENARIO_SKIP_CONSISTENCY_CHECKS` envvar and skip it altogether. Hopefully you
 don't need that.
+
+## Adjusting the log level
+
+Set `OP_SCENARIO_LOGGING` to one of the standard log level names (such as
+`DEBUG` or `WARNING`) to change the level at which Scenario logs.
+
+## Adjusting the spec cache size
+
+Each time a `Context` object is created, the `charmcraft.yaml`
+(or `metadata.yaml`, `actions.yaml`, and `config.yaml`) data is loaded from
+disk and deserialised, if the data is not passed as dictionaries. In most cases,
+each test uses a new `Context` object, and the YAML does not change from test to
+test. To avoid unnecessary work, Scenario caches the loaded data for up to four
+charms. If your tests are working with a lot of different charms, you should get
+a performance benefit by changing `SCENARIO_SPEC_CACHE_SIZE` to a larger value.
 
 # Jhack integrations
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -1172,28 +1172,11 @@ That happens automatically behind the scenes whenever you trigger an event;
   working on a machine charm or don't have either way a `bar` container in your `metadata.yaml`, Scenario will flag that
   as inconsistent.
 
-# Overriding default behaviour
-
 ## Bypassing the checker
 
 If you have a clear false negative, are explicitly testing 'edge', inconsistent situations, or for whatever reason the
 checker is in your way, you can set the `SCENARIO_SKIP_CONSISTENCY_CHECKS` envvar and skip it altogether. Hopefully you
 don't need that.
-
-## Adjusting the log level
-
-Set `OP_SCENARIO_LOGGING` to one of the standard log level names (such as
-`DEBUG` or `WARNING`) to change the level at which Scenario logs.
-
-## Adjusting the spec cache size
-
-Each time a `Context` object is created, the `charmcraft.yaml`
-(or `metadata.yaml`, `actions.yaml`, and `config.yaml`) data is loaded from
-disk and deserialised, if the data is not passed as dictionaries. In most cases,
-each test uses a new `Context` object, and the YAML does not change from test to
-test. To avoid unnecessary work, Scenario caches the loaded data for up to four
-charms. If your tests are working with a lot of different charms, you should get
-a performance benefit by changing `SCENARIO_SPEC_CACHE_SIZE` to a larger value.
 
 # Jhack integrations
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -66,7 +66,7 @@ Comparing scenario tests with `Harness` tests:
 A scenario test consists of three broad steps:
 
 - **Arrange**:
-    - declare the context 
+    - declare the context
     - declare the input state
     - select an event to fire
 - **Act**:
@@ -173,7 +173,7 @@ def test_statuses():
         scenario.WaitingStatus('checking this is right...'),
     ]
     assert out.unit_status == scenario.ActiveStatus("I am ruled")
-    
+
     # similarly you can check the app status history:
     assert ctx.app_status_history == [
         scenario.UnknownStatus(),
@@ -241,7 +241,7 @@ def test_foo():
 
 You can configure what events will be captured by passing the following arguments to `Context`:
 -  `capture_deferred_events`: If you want to include re-emitted deferred events.
--  `capture_framework_events`: If you want to include framework events (`pre-commit`, `commit`, and `collect-status`). 
+-  `capture_framework_events`: If you want to include framework events (`pre-commit`, `commit`, and `collect-status`).
 
 For example:
 ```python
@@ -360,10 +360,10 @@ ctx.run(ctx.on.start(), state_in)  # invalid: this unit's id cannot be the ID of
 
 To declare a subordinate relation, you should use `scenario.SubordinateRelation`. The core difference with regular
 relations is that subordinate relations always have exactly one remote unit (there is always exactly one remote unit
-that this unit can see). 
+that this unit can see).
 Because of that, `SubordinateRelation`, compared to `Relation`, always talks in terms of `remote`:
 
-- `Relation.remote_units_data` becomes `SubordinateRelation.remote_unit_data` taking a single `Dict[str:str]`. The remote unit ID can be provided as a separate argument. 
+- `Relation.remote_units_data` becomes `SubordinateRelation.remote_unit_data` taking a single `Dict[str:str]`. The remote unit ID can be provided as a separate argument.
 - `Relation.remote_unit_ids` becomes `SubordinateRelation.remote_unit_id` (a single ID instead of a list of IDs)
 - `Relation.remote_units_data` becomes `SubordinateRelation.remote_unit_data` (a single databag instead of a mapping from unit IDs to databags)
 
@@ -414,10 +414,10 @@ remote_unit_2_is_joining_event = ctx.on.relation_joined(relation, remote_unit=2)
 
 ## Networks
 
-Simplifying a bit the Juju "spaces" model, each integration endpoint a charm defines in its metadata is associated with a network. Regardless of whether there is a living relation over that endpoint, that is.  
+Simplifying a bit the Juju "spaces" model, each integration endpoint a charm defines in its metadata is associated with a network. Regardless of whether there is a living relation over that endpoint, that is.
 
 If your charm has a relation `"foo"` (defined in its metadata), then the charm will be able at runtime to do `self.model.get_binding("foo").network`.
-The network you'll get by doing so is heavily defaulted (see `state.Network`) and good for most use-cases because the charm should typically not be concerned about what IP it gets. 
+The network you'll get by doing so is heavily defaulted (see `state.Network`) and good for most use-cases because the charm should typically not be concerned about what IP it gets.
 
 On top of the relation-provided network bindings, a charm can also define some `extra-bindings` in its metadata and access them at runtime. Note that this is a deprecated feature that should not be relied upon. For completeness, we support it in Scenario.
 
@@ -540,7 +540,7 @@ def test_pebble_push():
         MyCharm,
         meta={"name": "foo", "containers": {"foo": {}}}
     )
-    
+
     ctx.run(ctx.on.start(), state_in)
 
     # This is the root of the simulated container filesystem. Any mounts will be symlinks in it.
@@ -724,7 +724,7 @@ ctx.run(ctx.on.storage_attached(foo_1), scenario.State(storages={foo_0, foo_1}))
 
 ## Ports
 
-Since `ops 2.6.0`, charms can invoke the `open-port`, `close-port`, and `opened-ports` hook tools to manage the ports opened on the host VM/container. Using the `State.opened_ports` API, you can: 
+Since `ops 2.6.0`, charms can invoke the `open-port`, `close-port`, and `opened-ports` hook tools to manage the ports opened on the host VM/container. Using the `State.opened_ports` API, you can:
 
 - simulate a charm run with a port opened by some previous execution
 ctx = scenario.Context(MyCharm, meta=MyCharm.META)
@@ -941,7 +941,7 @@ How to test actions with scenario:
 def test_backup_action():
     ctx = scenario.Context(MyCharm)
 
-    # If you didn't declare do_backup in the charm's metadata, 
+    # If you didn't declare do_backup in the charm's metadata,
     # the `ConsistencyChecker` will slap you on the wrist and refuse to proceed.
     state = ctx.run(ctx.on.action("do_backup"), scenario.State())
 
@@ -979,7 +979,7 @@ If the action takes parameters, you can pass those in the call.
 def test_backup_action():
     ctx = scenario.Context(MyCharm)
 
-    # If the parameters (or their type) don't match what is declared in the metadata, 
+    # If the parameters (or their type) don't match what is declared in the metadata,
     # the `ConsistencyChecker` will slap you on the other wrist.
     state = ctx.run(
         ctx.on.action("do_backup", params={'a': 'b'}),
@@ -1052,7 +1052,7 @@ from charms.bar.lib_name.v1.charm_lib import CharmLib
 class MyCharm(ops.CharmBase):
     META = {"name": "mycharm"}
     _stored = ops.StoredState()
-    
+
     def __init__(self, framework):
         super().__init__(framework)
         self._stored.set_default(a="a")
@@ -1068,7 +1068,7 @@ def test_live_charm_introspection(mycharm):
     with ctx(ctx.on.start(), scenario.State()) as manager:
         # This is your charm instance, after ops has set it up:
         charm: MyCharm = manager.charm
-        
+
         # We can check attributes on nested Objects or the charm itself:
         assert charm.my_charm_lib.foo == "foo"
         # such as stored state:
@@ -1076,7 +1076,7 @@ def test_live_charm_introspection(mycharm):
 
         # This will tell ops.main to proceed with normal execution and emit the "start" event on the charm:
         state_out = manager.run()
-    
+
         # After that is done, we are handed back control, and we can again do some introspection:
         assert charm.my_charm_lib.foo == "bar"
         # and check that the charm's internal state is as we expect:
@@ -1181,6 +1181,6 @@ don't need that.
 # Jhack integrations
 
 Up until `v5.6.0`, Scenario shipped with a cli tool called `snapshot`, used to interact with a live charm's state.
-The functionality [has been moved over to `jhack`](https://github.com/PietroPasotti/jhack/pull/111), 
-to allow us to keep working on it independently, and to streamline 
+The functionality [has been moved over to `jhack`](https://github.com/PietroPasotti/jhack/pull/111),
+to allow us to keep working on it independently, and to streamline
 the profile of Scenario itself as it becomes more broadly adopted and ready for widespread usage.

--- a/testing/src/scenario/__init__.py
+++ b/testing/src/scenario/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -126,14 +126,7 @@ class Ops(_Manager):
         )
 
     def _load_charm_meta(self):
-        metadata = (self._charm_root / "metadata.yaml").read_text()
-        actions_meta = self._charm_root / "actions.yaml"
-        if actions_meta.exists():
-            actions_metadata = actions_meta.read_text()
-        else:
-            actions_metadata = None
-
-        return ops.CharmMeta.from_yaml(metadata, actions_metadata)
+        return ops.CharmMeta(self.charm_spec.meta, self.charm_spec.actions)
 
     def _setup_root_logging(self):
         # Ops sets sys.excepthook to go to Juju's debug-log, but that's not

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -500,7 +500,7 @@ class Context(Generic[CharmType]):
         if not any((meta, actions, config)):
             logger.debug("Autoloading charmspec...")
             try:
-                spec: _CharmSpec[CharmType] = _CharmSpec.autoload(charm_type)
+                spec: _CharmSpec[CharmType] = _CharmSpec.autoload(charm_type)  # type: ignore
             except MetadataNotFoundError as e:
                 raise ContextSetupError(
                     f"Cannot setup scenario with `charm_type`={charm_type}. "

--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -499,7 +499,7 @@ class Context(Generic[CharmType]):
         if not any((meta, actions, config)):
             logger.debug("Autoloading charmspec...")
             try:
-                spec: _CharmSpec[CharmType] = _CharmSpec.autoload(charm_type)  # type: ignore
+                spec: _CharmSpec[CharmType] = _CharmSpec.autoload(charm_type)
             except MetadataNotFoundError as e:
                 raise ContextSetupError(
                     f"Cannot setup scenario with `charm_type`={charm_type}. "

--- a/testing/src/scenario/errors.py
+++ b/testing/src/scenario/errors.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/logger.py
+++ b/testing/src/scenario/logger.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1627,8 +1627,8 @@ class _CharmSpec(Generic[CharmType]):
         actions = yaml.safe_load(actions_path.open()) if actions_path.exists() else None
         return meta, config, actions
 
-    @functools.lru_cache
     @staticmethod
+    @functools.lru_cache
     def _load_metadata(charm_root: pathlib.Path):
         """Load metadata from charm projects created with Charmcraft >= 2.5."""
         metadata_path = charm_root / "charmcraft.yaml"

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -10,7 +10,6 @@ import dataclasses
 import datetime
 import functools
 import inspect
-import os
 import pathlib
 import random
 import re
@@ -1628,6 +1627,7 @@ class _CharmSpec(Generic[CharmType]):
         actions = yaml.safe_load(actions_path.open()) if actions_path.exists() else None
         return meta, config, actions
 
+    @functools.lru_cache
     @staticmethod
     def _load_metadata(charm_root: pathlib.Path):
         """Load metadata from charm projects created with Charmcraft >= 2.5."""
@@ -1641,7 +1641,6 @@ class _CharmSpec(Generic[CharmType]):
         actions = meta.pop("actions", None)
         return meta, config, actions
 
-    @functools.lru_cache(int(os.environ.get("SCENARIO_SPEC_CACHE_SIZE", "4")))
     @staticmethod
     def autoload(charm_type: type[CharmBase]) -> _CharmSpec[CharmType]:
         """Construct a ``_CharmSpec`` object by looking up the metadata from the charm's repo root.

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import functools
 import inspect
+import os
 import pathlib
 import random
 import re
@@ -1639,6 +1641,7 @@ class _CharmSpec(Generic[CharmType]):
         actions = meta.pop("actions", None)
         return meta, config, actions
 
+    @functools.lru_cache(int(os.environ.get("SCENARIO_SPEC_CACHE_SIZE", "4")))
     @staticmethod
     def autoload(charm_type: type[CharmBase]) -> _CharmSpec[CharmType]:
         """Construct a ``_CharmSpec`` object by looking up the metadata from the charm's repo root.

--- a/testing/tests/test_e2e/test_pebble.py
+++ b/testing/tests/test_e2e/test_pebble.py
@@ -162,23 +162,23 @@ def test_fs_pull(charm_cls, make_dirs):
 
 
 LS = """
-.rw-rw-r--  228 ubuntu ubuntu 18 jan 12:05 -- charmcraft.yaml    
-.rw-rw-r--  497 ubuntu ubuntu 18 jan 12:05 -- config.yaml        
-.rw-rw-r--  900 ubuntu ubuntu 18 jan 12:05 -- CONTRIBUTING.md    
-drwxrwxr-x    - ubuntu ubuntu 18 jan 12:06 -- lib                
-.rw-rw-r--  11k ubuntu ubuntu 18 jan 12:05 -- LICENSE            
-.rw-rw-r-- 1,6k ubuntu ubuntu 18 jan 12:05 -- metadata.yaml      
-.rw-rw-r--  845 ubuntu ubuntu 18 jan 12:05 -- pyproject.toml     
-.rw-rw-r--  831 ubuntu ubuntu 18 jan 12:05 -- README.md          
-.rw-rw-r--   13 ubuntu ubuntu 18 jan 12:05 -- requirements.txt   
-drwxrwxr-x    - ubuntu ubuntu 18 jan 12:05 -- src                
-drwxrwxr-x    - ubuntu ubuntu 18 jan 12:05 -- tests              
-.rw-rw-r-- 1,9k ubuntu ubuntu 18 jan 12:05 -- tox.ini            
+.rw-rw-r--  228 ubuntu ubuntu 18 jan 12:05 -- charmcraft.yaml
+.rw-rw-r--  497 ubuntu ubuntu 18 jan 12:05 -- config.yaml
+.rw-rw-r--  900 ubuntu ubuntu 18 jan 12:05 -- CONTRIBUTING.md
+drwxrwxr-x    - ubuntu ubuntu 18 jan 12:06 -- lib
+.rw-rw-r--  11k ubuntu ubuntu 18 jan 12:05 -- LICENSE
+.rw-rw-r-- 1,6k ubuntu ubuntu 18 jan 12:05 -- metadata.yaml
+.rw-rw-r--  845 ubuntu ubuntu 18 jan 12:05 -- pyproject.toml
+.rw-rw-r--  831 ubuntu ubuntu 18 jan 12:05 -- README.md
+.rw-rw-r--   13 ubuntu ubuntu 18 jan 12:05 -- requirements.txt
+drwxrwxr-x    - ubuntu ubuntu 18 jan 12:05 -- src
+drwxrwxr-x    - ubuntu ubuntu 18 jan 12:05 -- tests
+.rw-rw-r-- 1,9k ubuntu ubuntu 18 jan 12:05 -- tox.ini
 """
 PS = """
-    PID TTY          TIME CMD    
- 298238 pts/3    00:00:04 zsh    
-1992454 pts/3    00:00:00 ps     
+    PID TTY          TIME CMD
+ 298238 pts/3    00:00:04 zsh
+1992454 pts/3    00:00:00 ps
 """
 
 

--- a/testing/tests/test_e2e/test_resource.py
+++ b/testing/tests/test_e2e/test_resource.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/testing/tox.ini
+++ b/testing/tox.ini
@@ -25,6 +25,7 @@ deps =
     jsonpatch
     pytest
     pytest-cov
+    -e ../
 setenv =
     PYTHONPATH = {toxinidir}
 commands =
@@ -43,7 +44,7 @@ commands =
 description = Static typing checks.
 skip_install = true
 deps =
-    ops~=2.15
+    -e ../
     pyright==1.1.347
 commands =
     pyright scenario


### PR DESCRIPTION
Work-in-progress PR. Submit to upstream once it's more complete.

Changes:
 * Create the ops.CharmMeta object using the dictionaries that we already have in the _CharmSpec object rather than loading and deserialising from disk.
 * Cache the metadata, config, and actions dictionaries that are loaded from charmcraft.yaml (or the separate YAML files) in the original charm directory.

It would be nice if we could avoid deserialising and writing the YAML files to the temporary charm directory. However, charms might be using those directly (I think we can say that they shouldn't for metadata.yaml, and probably actions.yaml - however CharmMeta does not currently load config.yaml, so it's legitimate to do that to get the defaults, for example). We could certainly cache the serialised form - we could perhaps symlink rather than write, but since the original form is possibly charmcraft.yaml, we'd need to write to one place, so that might not be a win. Biggest question is whether the charm tests actually need these files.

At the moment, timing is not necessarily a win:

|Suite|main|branch|
|-|-|-|
|operator/testing unit tests|6.63s|6.65s|
|traefik scenario tests (`upstream/scenario-7-migraine`) |63.14s|57.21s|
|kafka-k8s-operator (`-e unit -- -s tests/unit/test_charm.py`) |4.71s|4.73s|

Once done, should resolve https://github.com/canonical/operator/issues/1498

There are some drive-by trailing whitespace fixes that come from running the pre-commit linting in the testing folder. Could move these out to a separate PR.

Similarly, shebangs are removed from files that aren't meant to be directly executed. Could move those out too.