### PR TITLE
feat: typed State JSON encoder/decoder

### DIFF
--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -117,6 +117,7 @@ This API for testing was previously called 'Scenario'.
 .. autoclass:: ops.testing.Resource
 .. autoclass:: ops.testing.Secret
 .. autoclass:: ops.testing.State
+.. autoclass:: ops.testing.StateSchemaVersionError
 .. autoclass:: ops.testing.Storage
 .. autoclass:: ops.testing.StoredState
 .. autoclass:: ops.testing.SubordinateRelation
@@ -135,3 +136,5 @@ This API for testing was previously called 'Scenario'.
 .. autoclass:: ops.testing.errors.NoObserverError
 .. autoclass:: ops.testing.errors.BadOwnerPath
 .. automethod:: ops.testing.layer_from_rockcraft
+.. autofunction:: ops.testing.decode_state
+.. autofunction:: ops.testing.encode_state

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -106,6 +106,7 @@ try:
         Resource,
         Secret,
         State,
+        StateSchemaVersionError,
         Storage,
         StoredState,
         SubordinateRelation,
@@ -114,6 +115,8 @@ try:
         UnitID,
         UnknownStatus,
         WaitingStatus,
+        decode_state,
+        encode_state,
         errors,
         layer_from_rockcraft,
     )
@@ -153,6 +156,7 @@ else:
         'Resource',
         'Secret',
         'State',
+        'StateSchemaVersionError',
         'Storage',
         'StoredState',
         'SubordinateRelation',
@@ -161,6 +165,8 @@ else:
         'UnitID',
         'UnknownStatus',
         'WaitingStatus',
+        'decode_state',
+        'encode_state',
         'errors',
         'layer_from_rockcraft',
     ])

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -85,6 +85,7 @@ def test_ops_testing_doc():
                 for line in testing_doc
                 if line.strip().startswith((
                     '.. autoclass:: ops.testing.',
+                    '.. autofunction:: ops.testing.',
                     '.. automethod:: ops.testing.',
                 ))
             })

--- a/testing/src/scenario/__init__.py
+++ b/testing/src/scenario/__init__.py
@@ -68,9 +68,9 @@ from __future__ import annotations
 
 from ops._private.harness import ActionFailed  # For backwards compatibility.
 
+from ._state_serde import StateSchemaVersionError, decode_state, encode_state
 from .context import CharmEvents, Context, Manager
 from .errors import StateValidationError  # For backwards compatibility.
-from ._state_serde import StateSchemaVersionError, decode_state, encode_state
 from .state import (
     ActiveStatus,
     Address,

--- a/testing/src/scenario/__init__.py
+++ b/testing/src/scenario/__init__.py
@@ -70,6 +70,7 @@ from ops._private.harness import ActionFailed  # For backwards compatibility.
 
 from .context import CharmEvents, Context, Manager
 from .errors import StateValidationError  # For backwards compatibility.
+from ._state_serde import StateSchemaVersionError, decode_state, encode_state
 from .state import (
     ActiveStatus,
     Address,
@@ -145,6 +146,7 @@ __all__ = [
     'Resource',
     'Secret',
     'State',
+    'StateSchemaVersionError',
     'StateValidationError',
     'Storage',
     'StoredState',
@@ -154,5 +156,7 @@ __all__ = [
     'UnitID',
     'UnknownStatus',
     'WaitingStatus',
+    'decode_state',
+    'encode_state',
     'layer_from_rockcraft',
 ]

--- a/testing/src/scenario/_state_serde.py
+++ b/testing/src/scenario/_state_serde.py
@@ -156,9 +156,7 @@ def _encode(obj: Any, path: str = 'state') -> Any:
     if isinstance(obj, enum.Enum):
         cls_name = type(obj).__name__
         if cls_name not in _PEBBLE_ENUM_TYPES:
-            raise TypeError(
-                f'Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}.'
-            )
+            raise TypeError(f'Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}.')
         return {_T: 'enum', 'cls': cls_name, 'name': obj.name}
 
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
@@ -207,9 +205,7 @@ def _encode(obj: Any, path: str = 'state') -> Any:
             }
         return {str(k): _encode(v, f'{path}.{k}') for k, v in obj.items()}
 
-    raise TypeError(
-        f'No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}.'
-    )
+    raise TypeError(f'No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}.')
 
 
 def encode_state(state: _state.State) -> str:

--- a/testing/src/scenario/_state_serde.py
+++ b/testing/src/scenario/_state_serde.py
@@ -1,9 +1,9 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Typed JSON encoder/decoder for ops.testing.State (Saddle, step 2).
+"""Typed JSON encoder/decoder for ops.testing.State.
 
-Public surface (re-exported via scenario and ops.testing):
+Public surface (re-exported via ops.testing):
 
     encode_state(state: State) -> str
     decode_state(payload: str) -> State
@@ -83,9 +83,7 @@ STATE_SCHEMA_VERSION = 1
 _T = '__t__'
 _TUPLE_SENTINEL = '__tuple__'
 
-# ---------------------------------------------------------------------------
 # Type registries
-# ---------------------------------------------------------------------------
 
 _PEBBLE_ENUM_TYPES: dict[str, type[enum.Enum]] = {
     'CheckLevel': pebble.CheckLevel,
@@ -123,18 +121,14 @@ def _build_dc_registry() -> None:
             _DC_TYPES[value.__name__] = value
 
 
-# ---------------------------------------------------------------------------
 # Errors
-# ---------------------------------------------------------------------------
 
 
 class StateSchemaVersionError(Exception):
     """Raised when a payload's ``state_schema_version`` is not supported by this ops version."""
 
 
-# ---------------------------------------------------------------------------
 # Encoder
-# ---------------------------------------------------------------------------
 
 
 def _encode(obj: Any, path: str = 'state') -> Any:
@@ -163,8 +157,7 @@ def _encode(obj: Any, path: str = 'state') -> Any:
         cls_name = type(obj).__name__
         if cls_name not in _PEBBLE_ENUM_TYPES:
             raise TypeError(
-                f'Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}. '
-                'Add it to _PEBBLE_ENUM_TYPES in testing/src/scenario/_state_serde.py.'
+                f'Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}.'
             )
         return {_T: 'enum', 'cls': cls_name, 'name': obj.name}
 
@@ -215,8 +208,7 @@ def _encode(obj: Any, path: str = 'state') -> Any:
         return {str(k): _encode(v, f'{path}.{k}') for k, v in obj.items()}
 
     raise TypeError(
-        f'No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}. '
-        'If this type is intentional, extend testing/src/scenario/_state_serde.py.'
+        f'No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}.'
     )
 
 
@@ -237,9 +229,7 @@ def encode_state(state: _state.State) -> str:
     return json.dumps(payload)
 
 
-# ---------------------------------------------------------------------------
 # Decoder
-# ---------------------------------------------------------------------------
 
 
 def _decode_v1(obj: Any) -> Any:

--- a/testing/src/scenario/_state_serde.py
+++ b/testing/src/scenario/_state_serde.py
@@ -23,18 +23,18 @@ Type envelopes
 ~~~~~~~~~~~~~~
 Non-primitive values are wrapped in a small envelope dict keyed on ``"__t__"``:
 
-    ``"dc"``          – any dataclass from ``scenario.state``
-    ``"status"``      – ``_EntityStatus`` subclasses (special ``__init__``)
-    ``"frozenset"``   – ``frozenset``
-    ``"set"``         – ``set``
-    ``"datetime"``    – ISO-8601 string
-    ``"timedelta"``   – ``total_seconds()`` float
-    ``"Path"``        – ``pathlib.Path`` string
-    ``"PurePosixPath"`` – ``pathlib.PurePosixPath`` string
-    ``"layer"``       – ``pebble.Layer`` via ``to_dict()``/``Layer(dict)``
-    ``"enum"``        – ``enum.Enum`` subclass (class name + member name)
-    ``"bytes"``       – base64-encoded bytes
-    ``"idict"``       – ``dict`` with ``int`` keys
+    ``"dc"``          - any dataclass from ``scenario.state``
+    ``"status"``      - ``_EntityStatus`` subclasses (special ``__init__``)
+    ``"frozenset"``   - ``frozenset``
+    ``"set"``         - ``set``
+    ``"datetime"``    - ISO-8601 string
+    ``"timedelta"``   - ``total_seconds()`` float
+    ``"Path"``        - ``pathlib.Path`` string
+    ``"PurePosixPath"`` - ``pathlib.PurePosixPath`` string
+    ``"layer"``       - ``pebble.Layer`` via ``to_dict()``/``Layer(dict)``
+    ``"enum"``        - ``enum.Enum`` subclass (class name + member name)
+    ``"bytes"``       - base64-encoded bytes
+    ``"idict"``       - ``dict`` with ``int`` keys
 
 Tuples use a list-based envelope: ``["__tuple__", elem, ...]``.
 
@@ -163,8 +163,8 @@ def _encode(obj: Any, path: str = 'state') -> Any:
         cls_name = type(obj).__name__
         if cls_name not in _PEBBLE_ENUM_TYPES:
             raise TypeError(
-                f"Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}. "
-                "Add it to _PEBBLE_ENUM_TYPES in testing/src/scenario/_state_serde.py."
+                f'Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}. '
+                'Add it to _PEBBLE_ENUM_TYPES in testing/src/scenario/_state_serde.py.'
             )
         return {_T: 'enum', 'cls': cls_name, 'name': obj.name}
 
@@ -215,8 +215,8 @@ def _encode(obj: Any, path: str = 'state') -> Any:
         return {str(k): _encode(v, f'{path}.{k}') for k, v in obj.items()}
 
     raise TypeError(
-        f"No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}. "
-        "If this type is intentional, extend testing/src/scenario/_state_serde.py."
+        f'No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}. '
+        'If this type is intentional, extend testing/src/scenario/_state_serde.py.'
     )
 
 
@@ -261,7 +261,7 @@ def _decode_v1(obj: Any) -> Any:
         name = obj['name']
         cls = _STATUS_TYPES.get(name)
         if cls is None:
-            raise TypeError(f"Unknown status name {name!r} in wire payload.")
+            raise TypeError(f'Unknown status name {name!r} in wire payload.')
         return cls() if name == 'unknown' else cls(obj['msg'])
 
     if kind == 'layer':
@@ -271,7 +271,7 @@ def _decode_v1(obj: Any) -> Any:
         cls_name = obj['cls']
         cls = _PEBBLE_ENUM_TYPES.get(cls_name)
         if cls is None:
-            raise TypeError(f"Unknown enum class {cls_name!r} in wire payload.")
+            raise TypeError(f'Unknown enum class {cls_name!r} in wire payload.')
         return cls[obj['name']]
 
     if kind == 'dc':
@@ -279,7 +279,7 @@ def _decode_v1(obj: Any) -> Any:
         cls_name = obj['cls']
         cls = _DC_TYPES.get(cls_name)
         if cls is None:
-            raise TypeError(f"Unknown dataclass {cls_name!r} in wire payload.")
+            raise TypeError(f'Unknown dataclass {cls_name!r} in wire payload.')
         fields = {k: _decode_v1(v) for k, v in obj['f'].items()}
         return cls(**fields)
 
@@ -307,7 +307,7 @@ def _decode_v1(obj: Any) -> Any:
     if kind == 'idict':
         return {int(k): _decode_v1(v) for k, v in obj['v'].items()}
 
-    raise TypeError(f"Unknown wire type tag {kind!r} in payload.")
+    raise TypeError(f'Unknown wire type tag {kind!r} in payload.')
 
 
 # Dispatch table keyed by schema version; new versions add an entry here.
@@ -329,13 +329,11 @@ def decode_state(payload: str) -> _state.State:
     decode_fn = _VERSION_DECODERS.get(version)  # type: ignore[arg-type]
     if decode_fn is None:
         raise StateSchemaVersionError(
-            f"Unsupported state_schema_version={version!r}. "
-            f"Supported versions: {sorted(_VERSION_DECODERS)}. "
-            "Upgrade ops to a version that supports this payload."
+            f'Unsupported state_schema_version={version!r}. '
+            f'Supported versions: {sorted(_VERSION_DECODERS)}. '
+            'Upgrade ops to a version that supports this payload.'
         )
     result = decode_fn(data['state'])
     if not isinstance(result, _state.State):
-        raise TypeError(
-            f"Decoded payload root is not a State: got {type(result).__name__!r}."
-        )
+        raise TypeError(f'Decoded payload root is not a State: got {type(result).__name__!r}.')
     return result

--- a/testing/src/scenario/_state_serde.py
+++ b/testing/src/scenario/_state_serde.py
@@ -1,0 +1,341 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Typed JSON encoder/decoder for ops.testing.State (Saddle, step 2).
+
+Public surface (re-exported via scenario and ops.testing):
+
+    encode_state(state: State) -> str
+    decode_state(payload: str) -> State
+    StateSchemaVersionError
+
+Wire format
+~~~~~~~~~~~
+Every payload is a JSON object with a top-level ``state_schema_version``
+integer and the encoded state tree::
+
+    {"state_schema_version": 1, "state": <encoded>}
+
+``decode_state`` reads the version and dispatches to a version-specific
+decoder.  Unsupported versions raise :class:`StateSchemaVersionError`.
+
+Type envelopes
+~~~~~~~~~~~~~~
+Non-primitive values are wrapped in a small envelope dict keyed on ``"__t__"``:
+
+    ``"dc"``          – any dataclass from ``scenario.state``
+    ``"status"``      – ``_EntityStatus`` subclasses (special ``__init__``)
+    ``"frozenset"``   – ``frozenset``
+    ``"set"``         – ``set``
+    ``"datetime"``    – ISO-8601 string
+    ``"timedelta"``   – ``total_seconds()`` float
+    ``"Path"``        – ``pathlib.Path`` string
+    ``"PurePosixPath"`` – ``pathlib.PurePosixPath`` string
+    ``"layer"``       – ``pebble.Layer`` via ``to_dict()``/``Layer(dict)``
+    ``"enum"``        – ``enum.Enum`` subclass (class name + member name)
+    ``"bytes"``       – base64-encoded bytes
+    ``"idict"``       – ``dict`` with ``int`` keys
+
+Tuples use a list-based envelope: ``["__tuple__", elem, ...]``.
+
+Plain ``list`` and ``dict`` with string keys carry no envelope.
+
+StoredState escape hatch
+~~~~~~~~~~~~~~~~~~~~~~~~
+``StoredState.content`` (and ``Container._base_plan``) may contain types
+that are a superset of JSON: ``bytes``, ``tuple``-vs-``list`` distinction,
+and bare ``set``s.  The typed escape hatch is **always-on**:
+
+* ``bytes``  → base64 via the ``"bytes"`` envelope.
+* ``tuple``  → ``["__tuple__", ...]`` list-based envelope.
+* ``set``    → ``"set"`` envelope.
+
+Any value that cannot be encoded raises ``TypeError`` from the encoder,
+including the dotted path through ``State`` at which the unrecognised type
+was found.  The decoder mirrors: an unknown ``"__t__"`` tag raises
+``TypeError``.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import datetime
+import enum
+import inspect
+import json
+import pathlib
+from typing import Any
+
+from ops import SecretRotate, pebble
+
+from . import state as _state
+
+__all__ = [
+    'STATE_SCHEMA_VERSION',
+    'StateSchemaVersionError',
+    'decode_state',
+    'encode_state',
+]
+
+STATE_SCHEMA_VERSION = 1
+
+_T = '__t__'
+_TUPLE_SENTINEL = '__tuple__'
+
+# ---------------------------------------------------------------------------
+# Type registries
+# ---------------------------------------------------------------------------
+
+_PEBBLE_ENUM_TYPES: dict[str, type[enum.Enum]] = {
+    'CheckLevel': pebble.CheckLevel,
+    'CheckStartup': pebble.CheckStartup,
+    'CheckStatus': pebble.CheckStatus,
+    'NoticeType': pebble.NoticeType,
+    'SecretRotate': SecretRotate,
+    'ServiceStartup': pebble.ServiceStartup,
+    'ServiceStatus': pebble.ServiceStatus,
+}
+
+_STATUS_TYPES: dict[str, type[_state._EntityStatus]] = {
+    'active': _state.ActiveStatus,
+    'blocked': _state.BlockedStatus,
+    'error': _state.ErrorStatus,
+    'maintenance': _state.MaintenanceStatus,
+    'unknown': _state.UnknownStatus,
+    'waiting': _state.WaitingStatus,
+}
+
+_DC_TYPES: dict[str, type] = {}
+
+
+def _build_dc_registry() -> None:
+    """Populate ``_DC_TYPES`` with every dataclass from ``scenario.state``."""
+    if _DC_TYPES:
+        return
+    for name in dir(_state):
+        value = getattr(_state, name)
+        if (
+            inspect.isclass(value)
+            and dataclasses.is_dataclass(value)
+            and value.__module__ == _state.__name__
+        ):
+            _DC_TYPES[value.__name__] = value
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class StateSchemaVersionError(Exception):
+    """Raised when a payload's ``state_schema_version`` is not supported by this ops version."""
+
+
+# ---------------------------------------------------------------------------
+# Encoder
+# ---------------------------------------------------------------------------
+
+
+def _encode(obj: Any, path: str = 'state') -> Any:
+    """Recursively encode *obj* into a JSON-compatible structure.
+
+    Raises:
+        TypeError: if *obj* (or any nested value) has no registered encoding,
+            including the dotted *path* through ``State`` in the message.
+    """
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+
+    if isinstance(obj, bytes):
+        return {_T: 'bytes', 'v': base64.b64encode(obj).decode('ascii')}
+
+    # _EntityStatus check must precede the generic dataclass check because
+    # status subclasses have custom __init__ signatures that cls(**fields) won't satisfy.
+    if isinstance(obj, _state._EntityStatus):
+        return {_T: 'status', 'name': obj.name, 'msg': obj.message}
+
+    if isinstance(obj, pebble.Layer):
+        return {_T: 'layer', 'v': obj.to_dict()}
+
+    # Enum check before dataclass: pebble enums are not dataclasses.
+    if isinstance(obj, enum.Enum):
+        cls_name = type(obj).__name__
+        if cls_name not in _PEBBLE_ENUM_TYPES:
+            raise TypeError(
+                f"Unrecognised enum type {type(obj).__qualname__!r} at path {path!r}. "
+                "Add it to _PEBBLE_ENUM_TYPES in testing/src/scenario/_state_serde.py."
+            )
+        return {_T: 'enum', 'cls': cls_name, 'name': obj.name}
+
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        encoded_fields = {}
+        for f in dataclasses.fields(obj):
+            val = getattr(obj, f.name)
+            encoded_fields[f.name] = _encode(val, f'{path}.{f.name}')
+        return {_T: 'dc', 'cls': type(obj).__name__, 'f': encoded_fields}
+
+    if isinstance(obj, datetime.datetime):
+        return {_T: 'datetime', 'v': obj.isoformat()}
+
+    if isinstance(obj, datetime.timedelta):
+        return {_T: 'timedelta', 'v': obj.total_seconds()}
+
+    # pathlib.Path is a concrete subclass of PurePosixPath on Linux; check it first
+    # so that concrete paths always get the 'Path' tag, not 'PurePosixPath'.
+    if isinstance(obj, pathlib.Path):
+        return {_T: 'Path', 'v': str(obj)}
+
+    if isinstance(obj, pathlib.PurePosixPath):
+        return {_T: 'PurePosixPath', 'v': str(obj)}
+
+    if isinstance(obj, pathlib.PurePath):
+        # Catch-all for PureWindowsPath and any other PurePath subclasses.
+        return {_T: 'PurePosixPath', 'v': str(obj)}
+
+    if isinstance(obj, frozenset):
+        return {_T: 'frozenset', 'v': [_encode(x, f'{path}[]') for x in obj]}
+
+    if isinstance(obj, set):
+        return {_T: 'set', 'v': [_encode(x, f'{path}[]') for x in obj]}
+
+    if isinstance(obj, tuple):
+        return [_TUPLE_SENTINEL] + [_encode(x, f'{path}[]') for x in obj]
+
+    if isinstance(obj, list):
+        return [_encode(x, f'{path}[{i}]') for i, x in enumerate(obj)]
+
+    if isinstance(obj, dict):
+        if obj and all(isinstance(k, int) for k in obj):
+            # JSON requires string keys; preserve int-keyed dicts with a tag.
+            return {
+                _T: 'idict',
+                'v': {str(k): _encode(v, f'{path}[{k}]') for k, v in obj.items()},
+            }
+        return {str(k): _encode(v, f'{path}.{k}') for k, v in obj.items()}
+
+    raise TypeError(
+        f"No JSON encoding for type {type(obj).__qualname__!r} at path {path!r}. "
+        "If this type is intentional, extend testing/src/scenario/_state_serde.py."
+    )
+
+
+def encode_state(state: _state.State) -> str:
+    """Serialise a :class:`~ops.testing.State` to a JSON string.
+
+    The payload includes a ``state_schema_version`` integer field for forward
+    compatibility.  Use :func:`decode_state` to round-trip the result back to
+    a ``State``.
+
+    Raises:
+        TypeError: if any field value in *state* has no registered encoding.
+    """
+    payload = {
+        'state_schema_version': STATE_SCHEMA_VERSION,
+        'state': _encode(state),
+    }
+    return json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# Decoder
+# ---------------------------------------------------------------------------
+
+
+def _decode_v1(obj: Any) -> Any:
+    """Decode a value produced by :func:`_encode` (schema version 1)."""
+    if isinstance(obj, list):
+        if obj and obj[0] == _TUPLE_SENTINEL:
+            return tuple(_decode_v1(x) for x in obj[1:])
+        return [_decode_v1(x) for x in obj]
+
+    if not isinstance(obj, dict):
+        return obj
+
+    kind = obj.get(_T)
+
+    if kind is None:
+        return {k: _decode_v1(v) for k, v in obj.items()}
+
+    if kind == 'status':
+        name = obj['name']
+        cls = _STATUS_TYPES.get(name)
+        if cls is None:
+            raise TypeError(f"Unknown status name {name!r} in wire payload.")
+        return cls() if name == 'unknown' else cls(obj['msg'])
+
+    if kind == 'layer':
+        return pebble.Layer(obj['v'])
+
+    if kind == 'enum':
+        cls_name = obj['cls']
+        cls = _PEBBLE_ENUM_TYPES.get(cls_name)
+        if cls is None:
+            raise TypeError(f"Unknown enum class {cls_name!r} in wire payload.")
+        return cls[obj['name']]
+
+    if kind == 'dc':
+        _build_dc_registry()
+        cls_name = obj['cls']
+        cls = _DC_TYPES.get(cls_name)
+        if cls is None:
+            raise TypeError(f"Unknown dataclass {cls_name!r} in wire payload.")
+        fields = {k: _decode_v1(v) for k, v in obj['f'].items()}
+        return cls(**fields)
+
+    if kind == 'datetime':
+        return datetime.datetime.fromisoformat(obj['v'])
+
+    if kind == 'timedelta':
+        return datetime.timedelta(seconds=obj['v'])
+
+    if kind == 'Path':
+        return pathlib.Path(obj['v'])
+
+    if kind == 'PurePosixPath':
+        return pathlib.PurePosixPath(obj['v'])
+
+    if kind == 'frozenset':
+        return frozenset(_decode_v1(x) for x in obj['v'])
+
+    if kind == 'set':
+        return {_decode_v1(x) for x in obj['v']}
+
+    if kind == 'bytes':
+        return base64.b64decode(obj['v'])
+
+    if kind == 'idict':
+        return {int(k): _decode_v1(v) for k, v in obj['v'].items()}
+
+    raise TypeError(f"Unknown wire type tag {kind!r} in payload.")
+
+
+# Dispatch table keyed by schema version; new versions add an entry here.
+_VERSION_DECODERS: dict[int, Any] = {
+    1: _decode_v1,
+}
+
+
+def decode_state(payload: str) -> _state.State:
+    """Decode a JSON string produced by :func:`encode_state` back to a :class:`~ops.testing.State`.
+
+    Raises:
+        StateSchemaVersionError: if the payload's ``state_schema_version`` is
+            not supported by this version of ops.
+        TypeError: if the payload contains an unknown type tag.
+    """
+    data = json.loads(payload)
+    version = data.get('state_schema_version')
+    decode_fn = _VERSION_DECODERS.get(version)  # type: ignore[arg-type]
+    if decode_fn is None:
+        raise StateSchemaVersionError(
+            f"Unsupported state_schema_version={version!r}. "
+            f"Supported versions: {sorted(_VERSION_DECODERS)}. "
+            "Upgrade ops to a version that supports this payload."
+        )
+    result = decode_fn(data['state'])
+    if not isinstance(result, _state.State):
+        raise TypeError(
+            f"Decoded payload root is not a State: got {type(result).__name__!r}."
+        )
+    return result

--- a/testing/tests/test_state_serde.py
+++ b/testing/tests/test_state_serde.py
@@ -10,7 +10,6 @@ import json
 import pathlib
 
 import pytest
-
 from scenario._state_serde import (
     STATE_SCHEMA_VERSION,
     StateSchemaVersionError,

--- a/testing/tests/test_state_serde.py
+++ b/testing/tests/test_state_serde.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-import base64
 import datetime
 import json
 import pathlib
 
 import pytest
-from ops import SecretRotate, pebble
-
 from scenario._state_serde import (
     STATE_SCHEMA_VERSION,
     StateSchemaVersionError,
@@ -26,24 +23,22 @@ from scenario.state import (
     CheckInfo,
     Container,
     DeferredEvent,
-    Exec,
     MaintenanceStatus,
-    Model,
     Mount,
-    Network,
     Notice,
     PeerRelation,
     Relation,
     Resource,
     Secret,
     State,
-    Storage,
     StoredState,
     TCPPort,
     UnknownStatus,
     WaitingStatus,
+    _EntityStatus,
 )
 
+from ops import SecretRotate, pebble
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,8 +68,10 @@ class TestFrozensetRoundtrip:
             ])
         )
         out = _roundtrip(state)
-        assert len(out.relations) == 1
-        rel = next(iter(out.relations))
+        rels = list(out.relations)
+        assert len(rels) == 1
+        rel = rels[0]
+        assert isinstance(rel, Relation)
         assert rel.endpoint == 'db'
         assert rel.remote_app_name == 'pg'
 
@@ -82,21 +79,21 @@ class TestFrozensetRoundtrip:
 class TestDatetimeRoundtrip:
     def test_naive_datetime(self):
         dt = datetime.datetime(2030, 6, 15, 12, 0, 0)
-        state = State(secrets=frozenset([
-            Secret(
-                tracked_content={'k': 'v'},
-                expire=dt,
-            )
-        ]))
+        state = State(
+            secrets=frozenset([
+                Secret(
+                    tracked_content={'k': 'v'},
+                    expire=dt,
+                )
+            ])
+        )
         out = _roundtrip(state)
         secret = next(iter(out.secrets))
         assert secret.expire == dt
 
     def test_aware_datetime(self):
         dt = datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
-        state = State(secrets=frozenset([
-            Secret(tracked_content={'k': 'v'}, expire=dt)
-        ]))
+        state = State(secrets=frozenset([Secret(tracked_content={'k': 'v'}, expire=dt)]))
         out = _roundtrip(state)
         assert next(iter(out.secrets)).expire == dt
 
@@ -110,9 +107,7 @@ class TestTimedeltaRoundtrip:
     def test_repeat_after(self):
         td = datetime.timedelta(hours=2, minutes=30)
         notice = Notice(key='example.com/test', repeat_after=td)
-        state = State(containers=frozenset([
-            Container(name='c', notices=[notice])
-        ]))
+        state = State(containers=frozenset([Container(name='c', notices=[notice])]))
         out = _roundtrip(state)
         container = next(iter(out.containers))
         assert container.notices[0].repeat_after == td
@@ -120,9 +115,7 @@ class TestTimedeltaRoundtrip:
     def test_expire_after(self):
         td = datetime.timedelta(days=7)
         notice = Notice(key='example.com/test', expire_after=td)
-        state = State(containers=frozenset([
-            Container(name='c', notices=[notice])
-        ]))
+        state = State(containers=frozenset([Container(name='c', notices=[notice])]))
         out = _roundtrip(state)
         assert next(iter(out.containers)).notices[0].expire_after == td
 
@@ -135,7 +128,7 @@ class TestTimedeltaRoundtrip:
 
 class TestPathRoundtrip:
     def test_path_in_resource(self):
-        p = pathlib.Path('/tmp/resource.tar.gz')
+        p = pathlib.Path('/tmp/resource.tar.gz')  # noqa: S108
         state = State(resources=frozenset([Resource(name='oci-image', path=p)]))
         out = _roundtrip(state)
         resource = next(iter(out.resources))
@@ -153,12 +146,14 @@ class TestPathRoundtrip:
 class TestPurePosixPathRoundtrip:
     def test_pure_posix_path_in_mount(self):
         loc = pathlib.PurePosixPath('/etc/config')
-        state = State(containers=frozenset([
-            Container(
-                name='myapp',
-                mounts={'cfg': Mount(location=loc, source=pathlib.Path('/tmp/cfg'))},
-            )
-        ]))
+        state = State(
+            containers=frozenset([
+                Container(
+                    name='myapp',
+                    mounts={'cfg': Mount(location=loc, source=pathlib.Path('/tmp/cfg'))},  # noqa: S108
+                )
+            ])
+        )
         out = _roundtrip(state)
         container = next(iter(out.containers))
         mount = container.mounts['cfg']
@@ -166,12 +161,14 @@ class TestPurePosixPathRoundtrip:
         assert isinstance(mount.location, pathlib.PurePosixPath)
 
     def test_string_location_stays_string(self):
-        state = State(containers=frozenset([
-            Container(
-                name='myapp',
-                mounts={'cfg': Mount(location='/etc/config', source='/tmp/cfg')},
-            )
-        ]))
+        state = State(
+            containers=frozenset([
+                Container(
+                    name='myapp',
+                    mounts={'cfg': Mount(location='/etc/config', source='/tmp/cfg')},  # noqa: S108
+                )
+            ])
+        )
         out = _roundtrip(state)
         container = next(iter(out.containers))
         assert container.mounts['cfg'].location == '/etc/config'
@@ -180,12 +177,14 @@ class TestPurePosixPathRoundtrip:
 
 class TestPebbleEnumRoundtrip:
     def test_service_status(self):
-        state = State(containers=frozenset([
-            Container(
-                name='app',
-                service_statuses={'svc': pebble.ServiceStatus.ACTIVE},
-            )
-        ]))
+        state = State(
+            containers=frozenset([
+                Container(
+                    name='app',
+                    service_statuses={'svc': pebble.ServiceStatus.ACTIVE},
+                )
+            ])
+        )
         out = _roundtrip(state)
         container = next(iter(out.containers))
         assert container.service_statuses['svc'] is pebble.ServiceStatus.ACTIVE
@@ -198,9 +197,7 @@ class TestPebbleEnumRoundtrip:
 
     def test_check_status(self):
         ci = CheckInfo(name='http', status=pebble.CheckStatus.DOWN, failures=3)
-        state = State(containers=frozenset([
-            Container(name='app', check_infos=frozenset([ci]))
-        ]))
+        state = State(containers=frozenset([Container(name='app', check_infos=frozenset([ci]))]))
         out = _roundtrip(state)
         container = next(iter(out.containers))
         info = container.get_check_info('http')
@@ -215,9 +212,11 @@ class TestPebbleEnumRoundtrip:
         assert info.level is pebble.CheckLevel.READY
 
     def test_secret_rotate(self):
-        state = State(secrets=frozenset([
-            Secret(tracked_content={'k': 'v'}, rotate=SecretRotate.HOURLY, owner='app')
-        ]))
+        state = State(
+            secrets=frozenset([
+                Secret(tracked_content={'k': 'v'}, rotate=SecretRotate.HOURLY, owner='app')
+            ])
+        )
         out = _roundtrip(state)
         secret = next(iter(out.secrets))
         assert secret.rotate is SecretRotate.HOURLY
@@ -234,9 +233,7 @@ class TestPebbleLayerRoundtrip:
                 }
             }
         })
-        state = State(containers=frozenset([
-            Container(name='app', layers={'base': layer})
-        ]))
+        state = State(containers=frozenset([Container(name='app', layers={'base': layer})]))
         out = _roundtrip(state)
         container = next(iter(out.containers))
         assert 'app' in container.layers['base'].services
@@ -250,13 +247,15 @@ class TestPebbleLayerRoundtrip:
 
 class TestIntKeyedDictRoundtrip:
     def test_remote_grants(self):
-        state = State(secrets=frozenset([
-            Secret(
-                tracked_content={'pass': 'abc'},
-                owner='app',
-                remote_grants={0: {'related-app'}, 2: {'other-app/0'}},
-            )
-        ]))
+        state = State(
+            secrets=frozenset([
+                Secret(
+                    tracked_content={'pass': 'abc'},
+                    owner='app',
+                    remote_grants={0: {'related-app'}, 2: {'other-app/0'}},
+                )
+            ])
+        )
         out = _roundtrip(state)
         secret = next(iter(out.secrets))
         assert secret.remote_grants[0] == {'related-app'}
@@ -264,14 +263,17 @@ class TestIntKeyedDictRoundtrip:
         assert all(isinstance(k, int) for k in secret.remote_grants)
 
     def test_remote_units_data(self):
-        state = State(relations=frozenset([
-            Relation(
-                endpoint='db',
-                remote_units_data={0: {'key': 'val'}, 1: {'key': 'other'}},
-            )
-        ]))
+        state = State(
+            relations=frozenset([
+                Relation(
+                    endpoint='db',
+                    remote_units_data={0: {'key': 'val'}, 1: {'key': 'other'}},
+                )
+            ])
+        )
         out = _roundtrip(state)
         rel = next(iter(out.relations))
+        assert isinstance(rel, Relation)
         assert rel.remote_units_data[0] == {'key': 'val'}
         assert rel.remote_units_data[1] == {'key': 'other'}
         assert all(isinstance(k, int) for k in rel.remote_units_data)
@@ -285,9 +287,7 @@ class TestIntKeyedDictRoundtrip:
 class TestBytesEscapeHatch:
     def test_bytes_in_stored_state(self):
         data = b'\x00\x01\x02\xff'
-        state = State(stored_states=frozenset([
-            StoredState(content={'blob': data})
-        ]))
+        state = State(stored_states=frozenset([StoredState(content={'blob': data})]))
         out = _roundtrip(state)
         ss = next(iter(out.stored_states))
         assert ss.content['blob'] == data
@@ -340,17 +340,13 @@ class TestSetEscapeHatch:
 
 class TestEncoderTypeError:
     def test_unrecognised_type_raises(self):
-        state = State(stored_states=frozenset([
-            StoredState(content={'obj': object()})
-        ]))
+        state = State(stored_states=frozenset([StoredState(content={'obj': object()})]))
         with pytest.raises(TypeError, match="No JSON encoding for type 'object'"):
             encode_state(state)
 
     def test_error_includes_path(self):
-        state = State(stored_states=frozenset([
-            StoredState(content={'bad': object()})
-        ]))
-        with pytest.raises(TypeError, match="path"):
+        state = State(stored_states=frozenset([StoredState(content={'bad': object()})]))
+        with pytest.raises(TypeError, match='path'):
             encode_state(state)
 
     def test_unrecognised_enum_raises(self):
@@ -359,31 +355,29 @@ class TestEncoderTypeError:
         class MyEnum(enum.Enum):
             VAL = 'val'
 
-        state = State(stored_states=frozenset([
-            StoredState(content={'e': MyEnum.VAL})
-        ]))
-        with pytest.raises(TypeError, match="Unrecognised enum type"):
+        state = State(stored_states=frozenset([StoredState(content={'e': MyEnum.VAL})]))
+        with pytest.raises(TypeError, match='Unrecognised enum type'):
             encode_state(state)
 
 
 class TestDecoderTypeError:
     def test_unknown_type_tag_raises(self):
-        with pytest.raises(TypeError, match="Unknown wire type tag"):
+        with pytest.raises(TypeError, match='Unknown wire type tag'):
             _decode_v1({'__t__': '__no_such_type__', 'v': None})
 
     def test_unknown_dataclass_raises(self):
-        with pytest.raises(TypeError, match="Unknown dataclass"):
+        with pytest.raises(TypeError, match='Unknown dataclass'):
             _decode_v1({'__t__': 'dc', 'cls': 'NoSuchClass', 'f': {}})
 
     def test_unknown_enum_class_raises(self):
-        with pytest.raises(TypeError, match="Unknown enum class"):
+        with pytest.raises(TypeError, match='Unknown enum class'):
             _decode_v1({'__t__': 'enum', 'cls': 'NoSuchEnum', 'name': 'FOO'})
 
 
 class TestSchemaVersionMismatch:
     def test_unknown_version_raises(self):
         payload = json.dumps({'state_schema_version': 9999, 'state': {}})
-        with pytest.raises(StateSchemaVersionError, match="9999"):
+        with pytest.raises(StateSchemaVersionError, match='9999'):
             decode_state(payload)
 
     def test_missing_version_raises(self):
@@ -404,14 +398,17 @@ class TestSchemaVersionMismatch:
 
 
 class TestStatusRoundtrip:
-    @pytest.mark.parametrize('status,cls', [
-        (ActiveStatus('ready'), ActiveStatus),
-        (BlockedStatus('needs config'), BlockedStatus),
-        (WaitingStatus('waiting for db'), WaitingStatus),
-        (MaintenanceStatus('updating'), MaintenanceStatus),
-        (UnknownStatus(), UnknownStatus),
-    ])
-    def test_status_roundtrip(self, status, cls):
+    @pytest.mark.parametrize(
+        'status,cls',
+        [
+            (ActiveStatus('ready'), ActiveStatus),
+            (BlockedStatus('needs config'), BlockedStatus),
+            (WaitingStatus('waiting for db'), WaitingStatus),
+            (MaintenanceStatus('updating'), MaintenanceStatus),
+            (UnknownStatus(), UnknownStatus),
+        ],
+    )
+    def test_status_roundtrip(self, status: _EntityStatus, cls: type[_EntityStatus]):
         state = State(unit_status=status, app_status=status)
         out = _roundtrip(state)
         assert isinstance(out.unit_status, cls)
@@ -425,7 +422,7 @@ class TestStatusRoundtrip:
 
 class TestFullStateRoundtrip:
     def test_non_trivial_state(self):
-        _first = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        first = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
         state = State(
             config={'log_level': 'debug', 'port': 8080, 'enabled': True},
             relations=frozenset([
@@ -461,9 +458,9 @@ class TestFullStateRoundtrip:
                             key='example.com/event',
                             type=pebble.NoticeType.CUSTOM,
                             repeat_after=datetime.timedelta(minutes=30),
-                            first_occurred=_first,
-                            last_occurred=_first,
-                            last_repeated=_first,
+                            first_occurred=first,
+                            last_occurred=first,
+                            last_repeated=first,
                         )
                     ],
                     check_infos=frozenset([
@@ -484,9 +481,7 @@ class TestFullStateRoundtrip:
                     remote_grants={0: {'related-app'}},
                 )
             ]),
-            resources=frozenset([
-                Resource(name='oci-image', path=pathlib.Path('/tmp/image.tar'))
-            ]),
+            resources=frozenset([Resource(name='oci-image', path=pathlib.Path('/tmp/image.tar'))]),  # noqa: S108
             stored_states=frozenset([
                 StoredState(
                     name='_stored',
@@ -523,6 +518,8 @@ class TestFullStateRoundtrip:
         # Relations
         db_in = next(r for r in state.relations if r.endpoint == 'db')
         db_out = next(r for r in out.relations if r.endpoint == 'db')
+        assert isinstance(db_in, Relation)
+        assert isinstance(db_out, Relation)
         assert db_out.remote_units_data == db_in.remote_units_data
         assert db_out.remote_app_data == db_in.remote_app_data
         assert all(isinstance(k, int) for k in db_out.remote_units_data)
@@ -530,6 +527,8 @@ class TestFullStateRoundtrip:
         # Peers
         peer_in = next(r for r in state.relations if r.endpoint == 'peers')
         peer_out = next(r for r in out.relations if r.endpoint == 'peers')
+        assert isinstance(peer_in, PeerRelation)
+        assert isinstance(peer_out, PeerRelation)
         assert peer_out.peers_data == peer_in.peers_data
 
         # Container
@@ -551,7 +550,7 @@ class TestFullStateRoundtrip:
         assert secret_out.tracked_content == {'password': 'hunter2'}
         assert secret_out.rotate is SecretRotate.DAILY
         assert secret_out.remote_grants[0] == {'related-app'}
-        assert isinstance(list(secret_out.remote_grants.keys())[0], int)
+        assert isinstance(next(iter(secret_out.remote_grants.keys())), int)
 
         # Resource
         res_out = next(iter(out.resources))

--- a/testing/tests/test_state_serde.py
+++ b/testing/tests/test_state_serde.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Unit tests for the typed State JSON encoder/decoder (Saddle step 2)."""
+"""Unit tests for the typed State JSON encoder/decoder."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import json
 import pathlib
 
 import pytest
+
 from scenario._state_serde import (
     STATE_SCHEMA_VERSION,
     StateSchemaVersionError,
@@ -40,18 +41,14 @@ from scenario.state import (
 
 from ops import SecretRotate, pebble
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _roundtrip(state: State) -> State:
     return decode_state(encode_state(state))
 
 
-# ---------------------------------------------------------------------------
 # Leaf-type round-trips
-# ---------------------------------------------------------------------------
 
 
 class TestFrozensetRoundtrip:
@@ -279,9 +276,7 @@ class TestIntKeyedDictRoundtrip:
         assert all(isinstance(k, int) for k in rel.remote_units_data)
 
 
-# ---------------------------------------------------------------------------
 # StoredState escape hatch
-# ---------------------------------------------------------------------------
 
 
 class TestBytesEscapeHatch:
@@ -333,9 +328,7 @@ class TestSetEscapeHatch:
         assert isinstance(ss.content['s'], set)
 
 
-# ---------------------------------------------------------------------------
 # Error paths
-# ---------------------------------------------------------------------------
 
 
 class TestEncoderTypeError:
@@ -392,9 +385,7 @@ class TestSchemaVersionMismatch:
         assert data['state_schema_version'] == STATE_SCHEMA_VERSION
 
 
-# ---------------------------------------------------------------------------
 # Status round-trips
-# ---------------------------------------------------------------------------
 
 
 class TestStatusRoundtrip:
@@ -415,9 +406,7 @@ class TestStatusRoundtrip:
         assert out.unit_status == status
 
 
-# ---------------------------------------------------------------------------
 # Full State round-trip (non-trivial fixture)
-# ---------------------------------------------------------------------------
 
 
 class TestFullStateRoundtrip:

--- a/testing/tests/test_state_serde.py
+++ b/testing/tests/test_state_serde.py
@@ -1,0 +1,584 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the typed State JSON encoder/decoder (Saddle step 2)."""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import json
+import pathlib
+
+import pytest
+from ops import SecretRotate, pebble
+
+from scenario._state_serde import (
+    STATE_SCHEMA_VERSION,
+    StateSchemaVersionError,
+    _decode_v1,
+    decode_state,
+    encode_state,
+)
+from scenario.state import (
+    ActiveStatus,
+    BlockedStatus,
+    CheckInfo,
+    Container,
+    DeferredEvent,
+    Exec,
+    MaintenanceStatus,
+    Model,
+    Mount,
+    Network,
+    Notice,
+    PeerRelation,
+    Relation,
+    Resource,
+    Secret,
+    State,
+    Storage,
+    StoredState,
+    TCPPort,
+    UnknownStatus,
+    WaitingStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip(state: State) -> State:
+    return decode_state(encode_state(state))
+
+
+# ---------------------------------------------------------------------------
+# Leaf-type round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestFrozensetRoundtrip:
+    def test_empty(self):
+        state = State()
+        out = _roundtrip(state)
+        assert out.relations == frozenset()
+        assert out.containers == frozenset()
+
+    def test_with_relations(self):
+        state = State(
+            relations=frozenset([
+                Relation(endpoint='db', remote_app_name='pg'),
+            ])
+        )
+        out = _roundtrip(state)
+        assert len(out.relations) == 1
+        rel = next(iter(out.relations))
+        assert rel.endpoint == 'db'
+        assert rel.remote_app_name == 'pg'
+
+
+class TestDatetimeRoundtrip:
+    def test_naive_datetime(self):
+        dt = datetime.datetime(2030, 6, 15, 12, 0, 0)
+        state = State(secrets=frozenset([
+            Secret(
+                tracked_content={'k': 'v'},
+                expire=dt,
+            )
+        ]))
+        out = _roundtrip(state)
+        secret = next(iter(out.secrets))
+        assert secret.expire == dt
+
+    def test_aware_datetime(self):
+        dt = datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
+        state = State(secrets=frozenset([
+            Secret(tracked_content={'k': 'v'}, expire=dt)
+        ]))
+        out = _roundtrip(state)
+        assert next(iter(out.secrets)).expire == dt
+
+    def test_none_datetime(self):
+        state = State(secrets=frozenset([Secret(tracked_content={'k': 'v'})]))
+        out = _roundtrip(state)
+        assert next(iter(out.secrets)).expire is None
+
+
+class TestTimedeltaRoundtrip:
+    def test_repeat_after(self):
+        td = datetime.timedelta(hours=2, minutes=30)
+        notice = Notice(key='example.com/test', repeat_after=td)
+        state = State(containers=frozenset([
+            Container(name='c', notices=[notice])
+        ]))
+        out = _roundtrip(state)
+        container = next(iter(out.containers))
+        assert container.notices[0].repeat_after == td
+
+    def test_expire_after(self):
+        td = datetime.timedelta(days=7)
+        notice = Notice(key='example.com/test', expire_after=td)
+        state = State(containers=frozenset([
+            Container(name='c', notices=[notice])
+        ]))
+        out = _roundtrip(state)
+        assert next(iter(out.containers)).notices[0].expire_after == td
+
+    def test_none_timedelta(self):
+        notice = Notice(key='example.com/test')
+        state = State(containers=frozenset([Container(name='c', notices=[notice])]))
+        out = _roundtrip(state)
+        assert next(iter(out.containers)).notices[0].repeat_after is None
+
+
+class TestPathRoundtrip:
+    def test_path_in_resource(self):
+        p = pathlib.Path('/tmp/resource.tar.gz')
+        state = State(resources=frozenset([Resource(name='oci-image', path=p)]))
+        out = _roundtrip(state)
+        resource = next(iter(out.resources))
+        assert resource.path == p
+        assert isinstance(resource.path, pathlib.Path)
+
+    def test_string_path_stays_string(self):
+        state = State(resources=frozenset([Resource(name='bin', path='/usr/bin/tool')]))
+        out = _roundtrip(state)
+        resource = next(iter(out.resources))
+        assert resource.path == '/usr/bin/tool'
+        assert isinstance(resource.path, str)
+
+
+class TestPurePosixPathRoundtrip:
+    def test_pure_posix_path_in_mount(self):
+        loc = pathlib.PurePosixPath('/etc/config')
+        state = State(containers=frozenset([
+            Container(
+                name='myapp',
+                mounts={'cfg': Mount(location=loc, source=pathlib.Path('/tmp/cfg'))},
+            )
+        ]))
+        out = _roundtrip(state)
+        container = next(iter(out.containers))
+        mount = container.mounts['cfg']
+        assert mount.location == loc
+        assert isinstance(mount.location, pathlib.PurePosixPath)
+
+    def test_string_location_stays_string(self):
+        state = State(containers=frozenset([
+            Container(
+                name='myapp',
+                mounts={'cfg': Mount(location='/etc/config', source='/tmp/cfg')},
+            )
+        ]))
+        out = _roundtrip(state)
+        container = next(iter(out.containers))
+        assert container.mounts['cfg'].location == '/etc/config'
+        assert isinstance(container.mounts['cfg'].location, str)
+
+
+class TestPebbleEnumRoundtrip:
+    def test_service_status(self):
+        state = State(containers=frozenset([
+            Container(
+                name='app',
+                service_statuses={'svc': pebble.ServiceStatus.ACTIVE},
+            )
+        ]))
+        out = _roundtrip(state)
+        container = next(iter(out.containers))
+        assert container.service_statuses['svc'] is pebble.ServiceStatus.ACTIVE
+
+    def test_notice_type(self):
+        notice = Notice(key='example.com/n', type=pebble.NoticeType.CUSTOM)
+        state = State(containers=frozenset([Container(name='c', notices=[notice])]))
+        out = _roundtrip(state)
+        assert next(iter(out.containers)).notices[0].type is pebble.NoticeType.CUSTOM
+
+    def test_check_status(self):
+        ci = CheckInfo(name='http', status=pebble.CheckStatus.DOWN, failures=3)
+        state = State(containers=frozenset([
+            Container(name='app', check_infos=frozenset([ci]))
+        ]))
+        out = _roundtrip(state)
+        container = next(iter(out.containers))
+        info = container.get_check_info('http')
+        assert info.status is pebble.CheckStatus.DOWN
+        assert info.failures == 3
+
+    def test_check_level(self):
+        ci = CheckInfo(name='ready', level=pebble.CheckLevel.READY)
+        state = State(containers=frozenset([Container(name='app', check_infos=frozenset([ci]))]))
+        out = _roundtrip(state)
+        info = next(iter(out.containers)).get_check_info('ready')
+        assert info.level is pebble.CheckLevel.READY
+
+    def test_secret_rotate(self):
+        state = State(secrets=frozenset([
+            Secret(tracked_content={'k': 'v'}, rotate=SecretRotate.HOURLY, owner='app')
+        ]))
+        out = _roundtrip(state)
+        secret = next(iter(out.secrets))
+        assert secret.rotate is SecretRotate.HOURLY
+
+
+class TestPebbleLayerRoundtrip:
+    def test_layer_in_container(self):
+        layer = pebble.Layer({
+            'services': {
+                'app': {
+                    'command': '/bin/app --port 8080',
+                    'startup': 'enabled',
+                    'override': 'replace',
+                }
+            }
+        })
+        state = State(containers=frozenset([
+            Container(name='app', layers={'base': layer})
+        ]))
+        out = _roundtrip(state)
+        container = next(iter(out.containers))
+        assert 'app' in container.layers['base'].services
+
+    def test_empty_layer(self):
+        layer = pebble.Layer({})
+        state = State(containers=frozenset([Container(name='c', layers={'l': layer})]))
+        out = _roundtrip(state)
+        assert 'l' in next(iter(out.containers)).layers
+
+
+class TestIntKeyedDictRoundtrip:
+    def test_remote_grants(self):
+        state = State(secrets=frozenset([
+            Secret(
+                tracked_content={'pass': 'abc'},
+                owner='app',
+                remote_grants={0: {'related-app'}, 2: {'other-app/0'}},
+            )
+        ]))
+        out = _roundtrip(state)
+        secret = next(iter(out.secrets))
+        assert secret.remote_grants[0] == {'related-app'}
+        assert secret.remote_grants[2] == {'other-app/0'}
+        assert all(isinstance(k, int) for k in secret.remote_grants)
+
+    def test_remote_units_data(self):
+        state = State(relations=frozenset([
+            Relation(
+                endpoint='db',
+                remote_units_data={0: {'key': 'val'}, 1: {'key': 'other'}},
+            )
+        ]))
+        out = _roundtrip(state)
+        rel = next(iter(out.relations))
+        assert rel.remote_units_data[0] == {'key': 'val'}
+        assert rel.remote_units_data[1] == {'key': 'other'}
+        assert all(isinstance(k, int) for k in rel.remote_units_data)
+
+
+# ---------------------------------------------------------------------------
+# StoredState escape hatch
+# ---------------------------------------------------------------------------
+
+
+class TestBytesEscapeHatch:
+    def test_bytes_in_stored_state(self):
+        data = b'\x00\x01\x02\xff'
+        state = State(stored_states=frozenset([
+            StoredState(content={'blob': data})
+        ]))
+        out = _roundtrip(state)
+        ss = next(iter(out.stored_states))
+        assert ss.content['blob'] == data
+        assert isinstance(ss.content['blob'], bytes)
+
+    def test_empty_bytes(self):
+        state = State(stored_states=frozenset([StoredState(content={'b': b''})]))
+        out = _roundtrip(state)
+        assert next(iter(out.stored_states)).content['b'] == b''
+
+
+class TestTupleEscapeHatch:
+    def test_tuple_in_stored_state(self):
+        pair = (1, 'hello', True)
+        state = State(stored_states=frozenset([StoredState(content={'pair': pair})]))
+        out = _roundtrip(state)
+        ss = next(iter(out.stored_states))
+        assert ss.content['pair'] == pair
+        assert isinstance(ss.content['pair'], tuple)
+
+    def test_nested_tuple(self):
+        nested = ((1, 2), (3, 4))
+        state = State(stored_states=frozenset([StoredState(content={'n': nested})]))
+        out = _roundtrip(state)
+        assert next(iter(out.stored_states)).content['n'] == nested
+
+    def test_list_stays_list(self):
+        lst = [1, 2, 3]
+        state = State(stored_states=frozenset([StoredState(content={'lst': lst})]))
+        out = _roundtrip(state)
+        ss_content = next(iter(out.stored_states)).content['lst']
+        assert ss_content == lst
+        assert isinstance(ss_content, list)
+
+
+class TestSetEscapeHatch:
+    def test_set_in_stored_state(self):
+        s = {'a', 'b', 'c'}
+        state = State(stored_states=frozenset([StoredState(content={'s': s})]))
+        out = _roundtrip(state)
+        ss = next(iter(out.stored_states))
+        assert ss.content['s'] == s
+        assert isinstance(ss.content['s'], set)
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestEncoderTypeError:
+    def test_unrecognised_type_raises(self):
+        state = State(stored_states=frozenset([
+            StoredState(content={'obj': object()})
+        ]))
+        with pytest.raises(TypeError, match="No JSON encoding for type 'object'"):
+            encode_state(state)
+
+    def test_error_includes_path(self):
+        state = State(stored_states=frozenset([
+            StoredState(content={'bad': object()})
+        ]))
+        with pytest.raises(TypeError, match="path"):
+            encode_state(state)
+
+    def test_unrecognised_enum_raises(self):
+        import enum
+
+        class MyEnum(enum.Enum):
+            VAL = 'val'
+
+        state = State(stored_states=frozenset([
+            StoredState(content={'e': MyEnum.VAL})
+        ]))
+        with pytest.raises(TypeError, match="Unrecognised enum type"):
+            encode_state(state)
+
+
+class TestDecoderTypeError:
+    def test_unknown_type_tag_raises(self):
+        with pytest.raises(TypeError, match="Unknown wire type tag"):
+            _decode_v1({'__t__': '__no_such_type__', 'v': None})
+
+    def test_unknown_dataclass_raises(self):
+        with pytest.raises(TypeError, match="Unknown dataclass"):
+            _decode_v1({'__t__': 'dc', 'cls': 'NoSuchClass', 'f': {}})
+
+    def test_unknown_enum_class_raises(self):
+        with pytest.raises(TypeError, match="Unknown enum class"):
+            _decode_v1({'__t__': 'enum', 'cls': 'NoSuchEnum', 'name': 'FOO'})
+
+
+class TestSchemaVersionMismatch:
+    def test_unknown_version_raises(self):
+        payload = json.dumps({'state_schema_version': 9999, 'state': {}})
+        with pytest.raises(StateSchemaVersionError, match="9999"):
+            decode_state(payload)
+
+    def test_missing_version_raises(self):
+        payload = json.dumps({'state': {}})
+        with pytest.raises(StateSchemaVersionError):
+            decode_state(payload)
+
+    def test_current_version_accepted(self):
+        state = State()
+        encoded = encode_state(state)
+        data = json.loads(encoded)
+        assert data['state_schema_version'] == STATE_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Status round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestStatusRoundtrip:
+    @pytest.mark.parametrize('status,cls', [
+        (ActiveStatus('ready'), ActiveStatus),
+        (BlockedStatus('needs config'), BlockedStatus),
+        (WaitingStatus('waiting for db'), WaitingStatus),
+        (MaintenanceStatus('updating'), MaintenanceStatus),
+        (UnknownStatus(), UnknownStatus),
+    ])
+    def test_status_roundtrip(self, status, cls):
+        state = State(unit_status=status, app_status=status)
+        out = _roundtrip(state)
+        assert isinstance(out.unit_status, cls)
+        assert out.unit_status == status
+
+
+# ---------------------------------------------------------------------------
+# Full State round-trip (non-trivial fixture)
+# ---------------------------------------------------------------------------
+
+
+class TestFullStateRoundtrip:
+    def test_non_trivial_state(self):
+        _first = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        state = State(
+            config={'log_level': 'debug', 'port': 8080, 'enabled': True},
+            relations=frozenset([
+                Relation(
+                    endpoint='db',
+                    remote_app_name='postgresql',
+                    remote_units_data={0: {'host': '10.0.0.1'}, 1: {'host': '10.0.0.2'}},
+                    remote_app_data={'version': '14'},
+                ),
+                PeerRelation(
+                    endpoint='peers',
+                    peers_data={1: {'leader': 'true'}},
+                ),
+            ]),
+            containers=frozenset([
+                Container(
+                    name='myapp',
+                    can_connect=True,
+                    layers={
+                        'base': pebble.Layer({
+                            'services': {
+                                'app': {
+                                    'command': '/bin/app',
+                                    'startup': 'enabled',
+                                    'override': 'replace',
+                                }
+                            }
+                        })
+                    },
+                    service_statuses={'app': pebble.ServiceStatus.ACTIVE},
+                    notices=[
+                        Notice(
+                            key='example.com/event',
+                            type=pebble.NoticeType.CUSTOM,
+                            repeat_after=datetime.timedelta(minutes=30),
+                            first_occurred=_first,
+                            last_occurred=_first,
+                            last_repeated=_first,
+                        )
+                    ],
+                    check_infos=frozenset([
+                        CheckInfo(
+                            name='http',
+                            level=pebble.CheckLevel.ALIVE,
+                            status=pebble.CheckStatus.UP,
+                        )
+                    ]),
+                )
+            ]),
+            secrets=frozenset([
+                Secret(
+                    tracked_content={'password': 'hunter2'},
+                    owner='app',
+                    expire=datetime.datetime(2030, 12, 31, tzinfo=datetime.timezone.utc),
+                    rotate=SecretRotate.DAILY,
+                    remote_grants={0: {'related-app'}},
+                )
+            ]),
+            resources=frozenset([
+                Resource(name='oci-image', path=pathlib.Path('/tmp/image.tar'))
+            ]),
+            stored_states=frozenset([
+                StoredState(
+                    name='_stored',
+                    owner_path='MyCharm',
+                    content={
+                        'count': 42,
+                        'raw': b'\xde\xad\xbe\xef',
+                        'coords': (1, 2, 3),
+                        'tags': {'alpha', 'beta'},
+                        'mapping': {'nested': True},
+                    },
+                )
+            ]),
+            opened_ports=frozenset([TCPPort(8080)]),
+            leader=True,
+            unit_status=ActiveStatus('ready'),
+            app_status=ActiveStatus('running'),
+            workload_version='1.2.3',
+            planned_units=3,
+            deferred=[
+                DeferredEvent(
+                    handle_path='MyCharm/on/config_changed[1]',
+                    owner='MyCharm',
+                    observer='_on_config_changed',
+                )
+            ],
+        )
+
+        out = _roundtrip(state)
+
+        # Config
+        assert out.config == state.config
+
+        # Relations
+        db_in = next(r for r in state.relations if r.endpoint == 'db')
+        db_out = next(r for r in out.relations if r.endpoint == 'db')
+        assert db_out.remote_units_data == db_in.remote_units_data
+        assert db_out.remote_app_data == db_in.remote_app_data
+        assert all(isinstance(k, int) for k in db_out.remote_units_data)
+
+        # Peers
+        peer_in = next(r for r in state.relations if r.endpoint == 'peers')
+        peer_out = next(r for r in out.relations if r.endpoint == 'peers')
+        assert peer_out.peers_data == peer_in.peers_data
+
+        # Container
+        c_out = next(iter(out.containers))
+        assert c_out.name == 'myapp'
+        assert c_out.can_connect is True
+        assert 'app' in c_out.layers['base'].services
+        assert c_out.service_statuses['app'] is pebble.ServiceStatus.ACTIVE
+        notice_out = c_out.notices[0]
+        assert notice_out.key == 'example.com/event'
+        assert notice_out.type is pebble.NoticeType.CUSTOM
+        assert notice_out.repeat_after == datetime.timedelta(minutes=30)
+        ci_out = c_out.get_check_info('http')
+        assert ci_out.status is pebble.CheckStatus.UP
+        assert ci_out.level is pebble.CheckLevel.ALIVE
+
+        # Secret
+        secret_out = next(iter(out.secrets))
+        assert secret_out.tracked_content == {'password': 'hunter2'}
+        assert secret_out.rotate is SecretRotate.DAILY
+        assert secret_out.remote_grants[0] == {'related-app'}
+        assert isinstance(list(secret_out.remote_grants.keys())[0], int)
+
+        # Resource
+        res_out = next(iter(out.resources))
+        assert res_out.name == 'oci-image'
+        assert isinstance(res_out.path, pathlib.Path)
+
+        # StoredState escape hatch
+        ss_out = next(iter(out.stored_states))
+        assert ss_out.content['count'] == 42
+        assert ss_out.content['raw'] == b'\xde\xad\xbe\xef'
+        assert isinstance(ss_out.content['raw'], bytes)
+        assert ss_out.content['coords'] == (1, 2, 3)
+        assert isinstance(ss_out.content['coords'], tuple)
+        assert ss_out.content['tags'] == {'alpha', 'beta'}
+        assert isinstance(ss_out.content['tags'], set)
+
+        # Ports
+        assert out.opened_ports == frozenset([TCPPort(8080)])
+
+        # Metadata
+        assert out.leader is True
+        assert out.unit_status == ActiveStatus('ready')
+        assert out.app_status == ActiveStatus('running')
+        assert out.workload_version == '1.2.3'
+        assert out.planned_units == 3
+
+        # Deferred events
+        assert len(out.deferred) == 1
+        assert out.deferred[0].handle_path == 'MyCharm/on/config_changed[1]'
+        assert out.deferred[0].owner == 'MyCharm'


### PR DESCRIPTION
Proof of concept implementation of **step 2** of the Saddle incremental delivery plan (OP085 §7, row 2: *Typed State (de)serialiser with full leaf-type coverage and the StoredState escape hatch*).

### What this PR adds

A new `testing/src/scenario/_state_serde.py` module with:

(Claude picked "serde", which is short for serialisation/deserialisation. I do not love it, even as a private name.)

- **`encode_state(state) -> str`**: serialises an `ops.testing.State` to a JSON string with a `state_schema_version` header
- **`decode_state(payload) -> State`**: round-trips a JSON string back to a `State`; dispatches by schema version via a `_VERSION_DECODERS` table; unsupported versions raise **`StateSchemaVersionError`**

All leaf types from the spec are covered:

| Type | Encoding |
|------|----------|
| `frozenset` | list on encode; `frozenset(...)` on decode |
| `datetime` / `timedelta` | ISO-8601 string / `total_seconds()` float |
| `pathlib.Path` / `PurePosixPath` | string with `"Path"` / `"PurePosixPath"` type tag |
| Pebble enums (`ServiceStatus`, `NoticeType`, `CheckLevel`, `CheckStartup`, `CheckStatus`, `SecretRotate`) | `{"__t__": "enum", "cls": …, "name": …}` |
| `pebble.Layer` | `to_dict()` / `Layer(dict)` round-trip |
| `int`-keyed dicts (`Secret.remote_grants`, `Relation.remote_units_data`, …) | `{"__t__": "idict", …}` envelope |

**StoredState escape hatch (always-on, no flag):**
- `bytes` → base64 via `"bytes"` envelope
- `tuple` → `["__tuple__", ...]` list-based envelope (list distinction preserved)
- `set` → `"set"` envelope

Unrecognised types raise `TypeError` from the encoder with the type name and dotted path through `State`. The decoder mirrors: unknown `"__t__"` tags raise `TypeError`.

### Public surface (via `ops.testing`)

```python
from ops import testing

payload = testing.encode_state(state_in)
state_out = testing.decode_state(payload)

# version mismatch:
from ops.testing import StateSchemaVersionError
```

### Relationship to step 1

This PR branches off `main` directly and exposes the serde as a standalone surface. When step 1 merges, its `_isolated_serde.py` wire can be swapped to use `encode_state`/`decode_state` from this module.