### PR TITLE
fix: clear cancel pipe state on the successful exec wait path

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -431,6 +431,10 @@ def _force_close_websocket(ws: _WebSocket):
     closing a socket doesn't wake up other threads that are blocked in
     ``recv()`` on the same socket; an OS-level shutdown of the connection
     does.
+
+    This reaches into websocket-client's ``WebSocket.sock`` (the underlying
+    ``socket.socket``) because the library exposes no public way to shut the
+    connection down without first closing the fd.
     """
     sock = ws.sock
     if sock is not None:
@@ -1828,15 +1832,19 @@ class ExecProcess(Generic[AnyStr]):
         # If stdin reader thread is running, stop it
         if self._cancel_stdin is not None:
             self._cancel_stdin()
+            self._cancel_stdin = None
 
         # Wait for all threads to finish (e.g., message barrier sent)
         for thread in self._threads:
             thread.join()
 
         # If we opened a cancel_reader pipe, close the read side now (write
-        # side was already closed by _cancel_stdin().
+        # side was already closed by _cancel_stdin()). Clear it afterwards so
+        # that a second call to _wait() (e.g. wait() then wait_output()) can't
+        # close the same fd again, matching _teardown_after_error().
         if self._cancel_reader is not None:
             os.close(self._cancel_reader)
+            self._cancel_reader = None
 
         # Close websockets (shutdown doesn't send CLOSE message or wait for response).
         self._control_ws.shutdown()

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -4177,6 +4177,30 @@ class TestExec:
         assert process._threads
         assert all(thread.daemon for thread in process._threads)
 
+    def test_wait_twice_does_not_double_close_cancel_pipe(self, client: MockClient):
+        """A successful _wait() must clear the cancel pipe so a second call is safe.
+
+        wait() and wait_output() both call _wait(); calling them in turn (or
+        wait() twice) used to os.close() the already-closed cancel_reader fd
+        and re-run _cancel_stdin(), raising OSError on the second call.
+        """
+        self.add_responses(client, '123', 0)
+        # A second wait_change response for the second _wait() call.
+        change = build_mock_change_dict('123')
+        assert 'tasks' in change and change['tasks'] is not None
+        change['tasks'][0]['data'] = {'exit-code': 0}
+        client.responses.append({'result': change})
+
+        with tempfile.TemporaryFile() as stdin:
+            stdin.write(b'foo\n')
+            stdin.seek(0)
+            process = client.exec(['foo'], stdin=stdin, encoding=None)
+            process.wait()
+            assert process._cancel_stdin is None
+            assert process._cancel_reader is None
+            # Must not raise (e.g. OSError from closing the fd a second time).
+            process._wait()
+
     def test_connect_websocket_error_closes_connected_websockets(self):
         """If a websocket fails to connect, the connected ones must be closed."""
 


### PR DESCRIPTION
The error path added in _teardown_after_error() nulls out _cancel_stdin and _cancel_reader after using them, but the success path in _wait() did not. Because both wait() and wait_output() call _wait(), calling them in turn (or wait() twice) would re-run _cancel_stdin() and os.close() the already-closed cancel_reader fd, raising OSError on the second call.

Clear both on the success path too, matching _teardown_after_error(), and add a regression test. Also note in _force_close_websocket() that it depends on websocket-client's internal WebSocket.sock attribute.